### PR TITLE
Python 3.4 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 python:
   - 2.7
-virtualenv:
-  system_site_packages: true
+  - "2.7_with_system_site_packages"
+  - 3.4
 install: 
   - pip install -r requirements.txt
 script:

--- a/ads/parser.py
+++ b/ads/parser.py
@@ -9,6 +9,7 @@ __author__ = "Andy Casey <andy@astrowizici.st>"
 # Standard library
 import datetime
 import time
+import six
 
 __all__ = ["rows", "ordering", "dates", "start"]
 
@@ -132,7 +133,7 @@ def affiliation(affiliation=None, pos=None):
                     "list-type of up to two integers")
 
             try:
-                pos = map(int, pos)
+                pos = list(map(int, pos))
             except (TypeError, ValueError):
                 raise TypeError("affiliation position must be an integer or "\
                     "list-type of up to two integers")
@@ -227,10 +228,10 @@ def properties(properties=None):
         " OPENACCESS, NONARTICLE, EPRINT, BOOK, PROCEEDINGS, CATALOG, SOFTWARE"
     available_properties_list = map(str.lower, available_properties.split(", "))
 
-    if isinstance(properties, str):
+    if isinstance(properties, (str, six.text_type)):
         properties = (properties, )
 
-    all_strings = lambda _: isinstance(_, str)
+    all_strings = lambda _: isinstance(_, (str, six.text_type))
     if not all(map(all_strings, properties)):
         raise TypeError("properties must be a string or list-type of strings")
 
@@ -319,7 +320,7 @@ def dates(input_dates):
         start_date = _date(start_date, default_month=1)
         end_date = _date(end_date, default_month=12)
 
-    elif isinstance(input_dates, (str, unicode)):
+    elif isinstance(input_dates, (str, six.text_type)):
 
         # We will accept "2002-", "2002..", "..2003", "2002..2003"
         # "2002/01..2002/08", "2002/04..", "2002/07", "2002-7", "2002-07

--- a/ads/tests/mocks.py
+++ b/ads/tests/mocks.py
@@ -3,7 +3,7 @@ Mock responses
 """
 
 from httpretty import HTTPretty
-from stubdata.solr import example_solr_response
+from .stubdata.solr import example_solr_response
 import json
 from collections import OrderedDict
 

--- a/ads/tests/test_models.py
+++ b/ads/tests/test_models.py
@@ -38,8 +38,8 @@ class TestBaseQuery(unittest.TestCase):
         # Write temporary file and override the config variable with the
         # tempfile paths
         tf1, tf2 = NamedTemporaryFile(), NamedTemporaryFile()
-        tf1.write('tok3\n')
-        tf2.write(' tok4 ')
+        tf1.write('tok3\n'.encode("utf-8"))
+        tf2.write(' tok4 '.encode("utf-8"))
         [f.flush() for f in [tf1, tf2]]
         [f.seek(0) for f in [tf1, tf2]]
         ads.core.TOKEN_FILES = [tf1.name, tf2.name]

--- a/ads/tests/test_models.py
+++ b/ads/tests/test_models.py
@@ -7,7 +7,7 @@ import unittest
 import ads.core
 from ads.core import SolrResponse, Article, BaseQuery
 from ads.exceptions import SolrResponseParseError, SolrResponseError
-from mocks import MockSolrResponse
+from .mocks import MockSolrResponse
 
 import requests
 import os

--- a/ads/tests/test_models.py
+++ b/ads/tests/test_models.py
@@ -11,6 +11,8 @@ from mocks import MockSolrResponse
 
 import requests
 import os
+import six
+
 from tempfile import NamedTemporaryFile
 
 
@@ -168,7 +170,7 @@ class TestArticle(unittest.TestCase):
         self.assertIsNone(self.article._references)
         self.assertIsNone(self.article._citations)
         self.assertIsNone(self.article._bibtex)
-        for key, value in self.article._raw.iteritems():
+        for key, value in six.iteritems(self.article._raw):
             self.assertEqual(
                 self.article.__getattribute__(key),
                 value,

--- a/ads/tests/test_searchquery.py
+++ b/ads/tests/test_searchquery.py
@@ -1,6 +1,7 @@
 """
 Tests for SearchQuery and it's query proxy class.
 """
+import sys
 import unittest
 
 from mocks import MockSolrResponse
@@ -51,13 +52,18 @@ class TestSearchQuery(unittest.TestCase):
         self.assertIn("star", sq.query['q'])
 
         sq = SearchQuery(title="t", author="ln, fn")
-        self.assertItemsEqual(
+
+        # In Python 3, assertItemsEqual is named assertCountEqual
+        assertItemsEqual = self.assertItemsEqual if sys.version_info[0] == 2 \
+            else self.assertCountEqual
+        
+        assertItemsEqual(
             sq.query['q'].split(),
             'title:"t" author:"ln, fn"'.split(),
         )
 
         sq = SearchQuery(q="star", aff="institute")
-        self.assertItemsEqual(
+        assertItemsEqual(
             sq.query['q'].split(),
             'aff:"institute" star'.split(),
         )

--- a/ads/tests/test_searchquery.py
+++ b/ads/tests/test_searchquery.py
@@ -4,7 +4,7 @@ Tests for SearchQuery and it's query proxy class.
 import sys
 import unittest
 
-from mocks import MockSolrResponse
+from .mocks import MockSolrResponse
 
 from ads.core import SearchQuery, query
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+six
 requests
 httpretty

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 # coding: utf-8
 
-""" A Python module for NASA's Astrophysical Data Service (ADS) that doesn't suck. """
+"""
+A Python module for NASA's Astrophysical Data Service (ADS) that doesn't suck.
+"""
 
 import os
 import re
@@ -24,8 +26,7 @@ def readfile(filename):
 version_regex = re.compile("__version__ = \"(.*?)\"")
 contents = readfile(os.path.join(
     os.path.dirname(os.path.abspath(__file__)),
-    "ads",
-    "__init__.py"))
+    "ads", "__init__.py"))
 
 version = version_regex.findall(contents)[0]
 
@@ -37,9 +38,8 @@ setup(name="ads",
       url="http://www.github.com/andycasey/ads/",
       license="MIT",
       description="A Python module for NASA's ADS that doesn't suck.",
-      long_description=readfile(os.path.join(os.path.dirname(__file__), "README.md")),
-      install_requires=[
-        "requests",
-        "requests_futures"
-      ]
+      long_description=\
+          readfile(os.path.join(os.path.dirname(__file__), "README.md")),
+      install_requires=\
+          readfile(os.path.join(os.path.dirname(__file__), "requirements.txt"))
      )


### PR DESCRIPTION
I extended your `adsabs/ads:devel` branch and made it Python 3.4 compatible. All tests locally on 2.7 and 3.4, but you may want to check the behaviour on 54574c3 to make sure it is as you originally intended.
